### PR TITLE
Determine exact version of ultralytics to avoid crashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ torchgeometry
 git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI
 git+https://github.com/mkocabas/yolov3-pytorch.git
 git+https://github.com/mkocabas/multi-person-tracker.git
+ultralytics==8.0.24


### PR DESCRIPTION
Hey @HongwenZhang 

I forgot to specify version of ultralytics in requirements. I thought that the latest version of ultralytics will be OK, but testing with the latest version crashed. I set the exact version of ultralytics that worked fine.

P.S. The crash is due to a subtle change in result data format, and nothing is wrong with the performance or the model.

Regards